### PR TITLE
fix: overlapping CGO_ENABLED = 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pre-commit-config.yaml
 result/
 /ess
+.devenv/

--- a/flake.nix
+++ b/flake.nix
@@ -66,12 +66,6 @@
                 go-tools
                 gopls
               ]);
-
-            shellHook =
-              # bash
-              ''
-                export CGO_ENABLED=0
-              '';
           };
         };
       }


### PR DESCRIPTION
When ess is a flake input to other devenv projects, it fails with the following:

> error: The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:
>   - CGO_ENABLED: in `env`: 0; in derivation arguments: 1
