### PR TITLE
fix: overlapping cgo enabled 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,6 @@
   ...
 }:
 pkgs.buildGoModule rec {
-  env.CGO_ENABLED = 0;
   pname = "ess";
   version = pkgs.lib.strings.removeSuffix "\n" (builtins.readFile ./version.txt);
   src = ./.;
@@ -13,6 +12,7 @@ pkgs.buildGoModule rec {
     "-X 'main.version=${version}-nix'"
     "-X 'main.commit=${self.rev or "dev"}'"
   ];
+  CGO_ENABLED = 0;
 
   meta = {
     description = "ess (env-sample-sync): automatically and safely synchronize env.sample files with .env";


### PR DESCRIPTION
`buildGoModule` already has a `CGO_ENABLED` input. Setting it with `env` overlaps.

> error: The env attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:

> CGO_ENABLED: in env: 0; in derivation arguments: 1